### PR TITLE
Changed _brightness initial value in WS2811 constructor to be in range

### DIFF
--- a/src/esp32WS2811.cpp
+++ b/src/esp32WS2811.cpp
@@ -55,7 +55,7 @@ WS2811::WS2811(int dataPin, size_t numLeds, int channel) :
   _dataPin(dataPin),
   _numLeds(numLeds),
   _leds(nullptr),
-  _brightness(255),
+  _brightness(100),
   _effect(nullptr) {
     _leds = new Led[_numLeds];
   }


### PR DESCRIPTION
Changed _brightness initial value in WS2811 constructor to be in range for brightness value (0-100%).
This fixes the brightness wrap-around problem in the FadeColours example.