### PR TITLE
Bugfix: correcting bitshift order to match ws2811 spec

### DIFF
--- a/src/esp32WS2811.cpp
+++ b/src/esp32WS2811.cpp
@@ -211,8 +211,8 @@ void WS2811::_handleRmt(WS2811* ws2811) {
     currentItem = &rmtItems[0];
     if (xSemaphoreTake(ws2811->_smphr, 100) == pdTRUE) {
       for (size_t i = 0; i < ws2811->_numLeds; ++i) {
-        uint32_t currentPixel = ws2811->_leds[i].green << 16 |
-                                ws2811->_leds[i].red << 8 |
+        uint32_t currentPixel = ws2811->_leds[i].red << 16 |
+                                ws2811->_leds[i].green << 8 |
                                 ws2811->_leds[i].blue;
         for (int8_t j = 23; j >= 0; --j) {
           // We have 24 bits of data representing the red, green and blue channels. The value of the


### PR DESCRIPTION
Whilst testing this library against a string of 50 WS2811 LED's I noticed that Colour(r, g, b) seemed to be mixing up the red and green channels.

Upon investigation it appears that this is a result of the bit shifting being incorrect.

Excerpt from the WS2811 spec:
```
Composition of 24bit Data
R7 R6 R5 R4 R3 R2 R1 R0 G7 G6 G5 G4 G3 G2 G1 G0 B7 B6 B5 B4 B3 B2 B1 B0
```
This is a breaking change. It now works correctly for my string of LED's but could potentially break for others (especially if they've added work arounds in their code for the issue).